### PR TITLE
[SVCS-2287] Fix Vanta vulnerabilities in MCP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,14 @@ RUN apt-get update && \
 
 # Upgrade pip and setuptools to latest secure versions
 # Fix CVE-2025-8869: Upgrade pip to 25.3+ (path traversal in tar extraction)
-RUN python -m pip install --upgrade 'pip>=25.3' 'setuptools>=78.1.1' wheel
+RUN python -m pip install --upgrade 'pip>=26.0' 'setuptools>=78.1.1' wheel
 
 COPY pyproject.toml ./
 COPY mcp_server/ ./mcp_server/
 
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir -e . && \
+    # Pin CVE-fixed versions for transitive deps that Inspector scans
+    pip install --no-cache-dir "PyJWT>=2.12.1" "jaraco.context>=6.1.0" "python-multipart>=0.0.22"
 
 ENV MCP_MODE=remote
 ENV MCP_HOST=0.0.0.0


### PR DESCRIPTION
## Summary
Pin CVE-fixed versions for transitive dependencies that AWS Inspector flags.

## Changes
- PyJWT >=2.12.1 (CVE-2026-32597 - crit header validation bypass)
- jaraco.context >=6.1.0 (CVE-2026-23949 - Zip Slip path traversal)
- python-multipart >=0.0.22 (CVE-2026-24486 - path traversal)
- pip >=26.0 (CVE-2026-1703 - tar extraction path traversal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)